### PR TITLE
feat: allow `Multipart` to be public

### DIFF
--- a/shelf_multipart/lib/multipart.dart
+++ b/shelf_multipart/lib/multipart.dart
@@ -54,7 +54,7 @@ extension ReadMultipartRequest on Request {
 
     return MimeMultipartTransformer(boundary)
         .bind(read())
-        .map((part) => Multipart._(this, part));
+        .map((part) => Multipart(this, part));
   }
 
   /// Extracts the `boundary` parameter from the content-type header, if this is
@@ -86,7 +86,7 @@ class Multipart extends MimeMultipart {
     return Encoding.getByName(contentType.parameters['charset']);
   }
 
-  Multipart._(this._originalRequest, this._inner)
+  Multipart(this._originalRequest, this._inner)
       : headers = CaseInsensitiveMap.from(_inner.headers);
 
   MediaType? _parseContentType() {


### PR DESCRIPTION
I'm working on a package which uses this package, but internally manages the Shelf Request instance so the body is readable more than once.

Currently the `Stream<Multipart> get parts` extension getter calls `read()` which doesn't work in this case. If the `Multipart` constructor was public, this would allow handling of internally reading the request body.